### PR TITLE
Reworked content handling to be dynamic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "portfolio",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "portfolio",
 	"type": "module",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build",

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,43 +1,31 @@
-import { glob } from 'astro/loaders';
 import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+import { ui } from './i18n/ui';
 
-const projectsEnCollection = defineCollection({
-	// Load Markdown files in the src/content/en/projects directory
-	loader: glob({ pattern: '**/*.md', base: './src/content/projects/en' }),
-	schema: z.object({
-		title: z.string(),
-		slug: z.string(),
-		locale: z.enum(['en', 'pt']),
-		github_url: z.string(),
-		description: z.string(),
-		publishDate: z.coerce.date(),
-		tags: z.array(z.string()),
-		img: z.string(),
-		img_alt: z.string().optional(),
-		imgs: z.array(z.array(z.string())).optional(),
-	}),
+const projectsSchema = z.object({
+	title: z.string(),
+	slug: z.string(),
+	locale: z.enum(Object.keys(ui) as [string, ...string[]]),
+	github_url: z.string(),
+	description: z.string(),
+	publishDate: z.coerce.date(),
+	tags: z.array(z.string()),
+	img: z.string(),
+	img_alt: z.string().optional(),
+	imgs: z.array(z.array(z.string())).optional(),
 });
 
-const projectsPtCollection = defineCollection({
-	// Load Markdown files in the src/content/pt/projects directory
-	loader: glob({ pattern: '**/*.md', base: './src/content/projects/pt' }),
-	schema: z.object({
-		title: z.string(),
-		slug: z.string(),
-		locale: z.enum(['en', 'pt']),
-		github_url: z.string(),
-		description: z.string(),
-		publishDate: z.coerce.date(),
-		tags: z.array(z.string()),
-		img: z.string(),
-		img_alt: z.string().optional(),
-		imgs: z.array(z.array(z.string())).optional(),
-	}),
-});
-
-const collections = {
-	projectsEn: projectsEnCollection,
-	projectsPt: projectsPtCollection,
-};
+const collections = Object.fromEntries(
+	Object.keys(ui).map((lang) => [
+		`projects${lang.charAt(0).toUpperCase() + lang.slice(1)}`,
+		defineCollection({
+			loader: glob({
+				pattern: '**/*.md',
+				base: `./src/content/projects/${lang}`,
+			}),
+			schema: projectsSchema,
+		}),
+	]),
+);
 
 export { collections };

--- a/src/utils/loadData.ts
+++ b/src/utils/loadData.ts
@@ -1,15 +1,11 @@
-import { getCollection, type CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
 import { collections } from '@/src/content.config';
 
 async function loadCollection(language = 'en') {
-	let projects: CollectionEntry[] = [];
-	switch (language) {
-		case 'pt':
-			projects = await getCollection('projectsPt');
-			break;
-		default:
-			projects = await getCollection('projectsEn');
-	}
+	const projects = await getCollection(
+		`projects${language.charAt(0).toUpperCase() + language.slice(1)}`,
+	);
+
 	return projects;
 }
 


### PR DESCRIPTION
## Summary
Reworked content handling to be dynamic, instead of having a collection manually and specifically created for each language;

## Changes
- Removed previous collections;
- As all the collections are similar in what data they contain, created a `projectsSchema` object to use with all the collections;
- Created a `collections` object to dynamically define collections to each existing language in the `ui` object from `i18n/ui.ts`;

## Notes
For more collections to be created, a new entry in the `ui` object from `i18n/ui.ts` needs to be added, as that is where the languages that currently exist are checked.
(In the future might change it to get them from the `language` object instead, makes more sense and is smaller and simpler)