### PR TITLE
Added umami events to the github redirect buttons and the CV button

### DIFF
--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -96,7 +96,12 @@ const t = useTranslations(locale);
 		</main>
 
 		<div class='cv-download'>
-			<a href={`${CDN}/assets/cv/CV_LeandroPata_EN.pdf`}>{t('about.cv')}</a>
+			<a 
+				href={`${CDN}/assets/cv/CV_LeandroPata_EN.pdf`} 
+				target='_blank' 
+				data-umami-event='CV Click'>
+				{t('about.cv')}
+			</a>
 		</div>
 		<ContactCTA />
 	</div>

--- a/src/pages/[lang]/projects/[...slug].astro
+++ b/src/pages/[lang]/projects/[...slug].astro
@@ -91,6 +91,7 @@ const { Content } = await render(page);
 							<a
 								href={page.data.github_url}
 								target='_blank'
+								data-umami-event='GitHub Click'
 								>{t('projects.gitRepo')}</a
 							>
 						</div>


### PR DESCRIPTION
## Summary
Added analytics to GitHub redirect and CV redirect, to check how often those elements are engaged;

## Changes
- Added a `data-umami-event` to GitHub redirect and CV redirect;

## Notes
New tests are going to be added later, as most of them are being reworked.