### PR TITLE
Fix for CDN delivery tests failing on PRs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "portfolio",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "portfolio",
 	"type": "module",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,7 +9,7 @@ export const LINKS = {
 export const REPO = {
 	NAME: 'Portfolio',
 	USER: 'LeandroPata',
-	VERSION: `v${version}`,
+	VERSION: `v${version.charAt(0)}`,
 };
 
 export const CDN = `https://cdn.jsdelivr.net/gh/${REPO.USER}/${REPO.NAME}@${REPO.VERSION}`;


### PR DESCRIPTION
# Fix for CDN delivery tests failing on PRs

## Summary

Fixed the CDN delivery tests failing on PRs, due to version bumps on the PR itself, causing the tests to check for CDN assets on a version that does not yet exist on the `main` branch.

This approach also reduces deployments, because the previous approach required the version tagging of the commits with new assets (or not bumping the version at all), which would trigger the GitHub action to test and deploy the site.

This way, assuming the major version is the same, the version can be bumped and not tagged in the commit (not triggering the GitHub action to deploy) and the CDN will still deliver the assets correctly.

## Changes

- Changed CDN check for only the major version instead of the full version;

## Notes

Also, if an asset does not exist on the most recent version and is still request, it will just fallback to the most recent version of the asset in a previous release.