### PR TITLE
Bugfixing the missing trailing slashes 

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,12 +1,13 @@
 // @ts-check
-import { defineConfig } from 'astro/config';
-import yeskunallumami from '@yeskunall/astro-umami';
 
 import sitemap from '@astrojs/sitemap';
+import yeskunallumami from '@yeskunall/astro-umami';
+import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://leandropata.pt',
+	trailingSlash: 'always',
 	integrations: [
 		sitemap({
 			i18n: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
 	use: {
 		navigationTimeout: 30 * 1000, // Timeout for navigation operations in milliseconds (30 sec)
 		actionTimeout: 15 * 1000, // Timeout for action operations in milliseconds (15 sec)
-		trace: 'on-first-retry',
+		trace: 'retain-on-first-failure',
 		baseURL: isProd ? 'https://leandropata.pt' : 'http://localhost:4321',
 		headless: isProd ? true : !!process.env.CI,
 		...(isProd && !process.env.CI

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -22,10 +22,12 @@ export function useTranslations(lang: keyof typeof ui) {
 export function useTranslatedPath(lang: keyof typeof languages) {
 	return function translatePath(path: string, l: string = lang) {
 		//console.log(`/${l}${path}`);
-		if (path === '/') {
-			return `/${l}`;
-		} else if (!path.startsWith('/')) {
+		if (!path.startsWith('/')) {
 			path = `/${path}`;
+		}
+
+		if (!path.endsWith('/')) {
+			path = `${path}/`;
 		}
 
 		return `/${l}${path}`;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,4 @@
 <meta
 	http-equiv='refresh'
-	content='0;url=/en'
+	content='0;url=/en/'
 />

--- a/src/utils/getRoutes.ts
+++ b/src/utils/getRoutes.ts
@@ -16,7 +16,7 @@ function getRoutes(dir: string, base: string = dir): string[] {
 				.replace(/index\.html$/, '') // Remove index.html extension
 				.replace(/\.html$/, '') // Remove .html extension
 				.replace(/\\/g, '/')}`; // Normalize for Windows
-			routes.push(url === '/' ? '/' : url);
+			routes.push(url.endsWith('/') ? url : `${url}/`);
 		}
 	}
 	//console.log(routes);

--- a/src/utils/getRoutes.ts
+++ b/src/utils/getRoutes.ts
@@ -1,4 +1,3 @@
-// tests/all-pages.spec.ts
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -16,7 +15,6 @@ function getRoutes(dir: string, base: string = dir): string[] {
 			const url = `/${relPath
 				.replace(/index\.html$/, '') // Remove index.html extension
 				.replace(/\.html$/, '') // Remove .html extension
-				.replace(/\/$/, '') // Remove trailing slashes
 				.replace(/\\/g, '/')}`; // Normalize for Windows
 			routes.push(url === '/' ? '/' : url);
 		}

--- a/test/E2ETesting/languageSelect.spec.ts
+++ b/test/E2ETesting/languageSelect.spec.ts
@@ -13,7 +13,7 @@ test.describe('Language selection works correctly', () => {
 				const curLocale = splicedRoute[1] === 'pt' ? 'pt' : 'en';
 				//console.log(`Current Locale: ${curLocale}`);
 				splicedRoute.splice(1, 1);
-				let baseRoute = splicedRoute.join('/');
+				let baseRoute = splicedRoute.join('/') || '/';
 
 				//console.log(`${route} : ${baseRoute}`);
 				//console.log(`${locale} : ${curLocale}`);

--- a/test/E2ETesting/nav.spec.ts
+++ b/test/E2ETesting/nav.spec.ts
@@ -6,7 +6,7 @@ test.describe('Navbar navigation', () => {
 		test(`Load all pages in navbar for the ${locale} locale`, async ({
 			page,
 		}) => {
-			await page.goto(`${locale}`);
+			await page.goto(`/${locale}/`);
 
 			await page.waitForSelector('#menu-toggle', {
 				state: 'attached',

--- a/test/E2ETesting/pageLoading.spec.ts
+++ b/test/E2ETesting/pageLoading.spec.ts
@@ -9,7 +9,7 @@ test.describe('All pages exist and load correctly', () => {
 		test(`Loads ${route}`, async ({ page }) => {
 			await page.goto(route);
 
-			if (route === '/') await expect(page).toHaveURL('/en');
+			if (route === '/') await expect(page).toHaveURL('/en/');
 			else await expect(page).toHaveURL(route);
 		});
 	}

--- a/test/E2ETesting/umami.spec.ts
+++ b/test/E2ETesting/umami.spec.ts
@@ -18,7 +18,10 @@ test('Umami script is present and reachable', async ({ page }) => {
 
 test.describe(`Umami events are reachable`, () => {
 	for (const route of routes) {
-		if (route.includes('/projects/') || route.includes('/about')) {
+		if (
+			(route.includes('/projects/') && !route.endsWith('/projects/')) ||
+			route.includes('/about/')
+		) {
 			test(`Events in ${route}`, async ({ page }) => {
 				await page.goto(route);
 

--- a/test/unitTesting/i18n.test.ts
+++ b/test/unitTesting/i18n.test.ts
@@ -20,12 +20,12 @@ import {
 describe('getLangFromUrl', () => {
 	it('Extracts a valid language from the URL', () => {
 		for (const lang of Object.keys(languages)) {
-			expect(getLangFromUrl(`/${lang}/about`)).toBe(lang);
+			expect(getLangFromUrl(`/${lang}/about/`)).toBe(lang);
 		}
 	});
 
 	it('Returns the default language when lang segment is missing', () => {
-		expect(getLangFromUrl('/about')).toBe(defaultLang);
+		expect(getLangFromUrl('/about/')).toBe(defaultLang);
 	});
 
 	it('Returns the default language for an unknown language segment', () => {
@@ -54,7 +54,7 @@ describe('getLangFromUrl', () => {
 // -------------------------------------------------------
 describe('getBaseUrl', () => {
 	it('Strips the language segment from a path', () => {
-		expect(getBaseUrl('/en/about')).toBe('/about');
+		expect(getBaseUrl('/en/about/')).toBe('/about/');
 	});
 
 	it('Handles the language root path', () => {
@@ -62,8 +62,8 @@ describe('getBaseUrl', () => {
 	});
 
 	it('Handles nested paths', () => {
-		expect(getBaseUrl('/en/projects/orderManagementApp')).toBe(
-			'/projects/orderManagementApp',
+		expect(getBaseUrl('/en/projects/orderManagementApp/')).toBe(
+			'/projects/orderManagementApp/',
 		);
 	});
 
@@ -73,7 +73,7 @@ describe('getBaseUrl', () => {
 
 	it('Works for all defined languages', () => {
 		for (const lang of Object.keys(languages)) {
-			expect(getBaseUrl(`/${lang}/about`)).toBe('/about');
+			expect(getBaseUrl(`/${lang}/about/`)).toBe('/about/');
 		}
 	});
 });
@@ -113,14 +113,14 @@ describe('useTranslatedPath', () => {
 	for (const lang in languages) {
 		const translatePath = useTranslatedPath(lang);
 		it(`Returns correct path for ${lang} locale`, () => {
-			expect(translatePath('/about', lang)).toBe(`/${lang}/about`);
+			expect(translatePath('/about/', lang)).toBe(`/${lang}/about/`);
 		});
 	}
 
 	const translatePath = useTranslatedPath(defaultLang);
 
 	it('Uses the default locale when none is provided', () => {
-		expect(translatePath('/about')).toBe(`/${defaultLang}/about`);
+		expect(translatePath('/about/')).toBe(`/${defaultLang}/about/`);
 	});
 
 	it('Overrides default locale when one is provided', () => {
@@ -128,21 +128,29 @@ describe('useTranslatedPath', () => {
 			(lang) => lang !== defaultLang,
 		)!;
 
-		expect(translatePath('/about', otherLang)).toBe(`/${otherLang}/about`);
+		expect(translatePath('/about/', otherLang)).toBe(`/${otherLang}/about/`);
 	});
 
 	it('Handles root path correctly', () => {
-		expect(translatePath('/')).toBe(`/${defaultLang}`);
+		expect(translatePath('/')).toBe(`/${defaultLang}/`);
 	});
 
 	it('Handles nested paths correctly', () => {
-		expect(translatePath('/projects/orderManagementApp')).toBe(
-			`/${defaultLang}/projects/orderManagementApp`,
+		expect(translatePath('/projects/orderManagementApp/')).toBe(
+			`/${defaultLang}/projects/orderManagementApp/`,
 		);
 	});
 
 	it('Handles without leading slash', () => {
-		expect(translatePath('about')).toBe(`/${defaultLang}/about`);
+		expect(translatePath('about/')).toBe(`/${defaultLang}/about/`);
+	});
+
+	it('Handles without trailing slash', () => {
+		expect(translatePath('/about')).toBe(`/${defaultLang}/about/`);
+	});
+
+	it('Handles without leading slash and trailing slash', () => {
+		expect(translatePath('about')).toBe(`/${defaultLang}/about/`);
 	});
 });
 


### PR DESCRIPTION
# Fixing the trailing slashes missing bugs

## Summary

Mostly reverting changes made in the previous tests rework patch, in which trailing slashes were mostly removed, largely due to personal preference.

Turns out GitHub Pages behavior enforces trailing slashes, making most tests fail due to expecting an URL without the trailing slash. Trailing slashes are now enforced whenever possible.

## Changes

- Added `trailingSlash: 'always'` to the astro config;
- Changed `trace` parameter in `playwright.config.ts` to `retain-on-first-failure`;
- Ensured all links have a trailing slash on multiple files and tests;