### PR TITLE
Bugfix/navbar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,10 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
 	site: 'https://leandropata.pt',
 	trailingSlash: 'always',
+	prefetch: {
+		prefetchAll: true,
+		defaultStrategy: 'viewport',
+	},
 	integrations: [
 		sitemap({
 			i18n: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "portfolio",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "portfolio",
-			"version": "1.1.1",
+			"version": "1.1.2",
 			"dependencies": {
 				"@astrojs/sitemap": "^3.3.0",
 				"@yeskunall/astro-umami": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "portfolio",
 	"type": "module",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
 	use: {
 		navigationTimeout: 30 * 1000, // Timeout for navigation operations in milliseconds (30 sec)
 		actionTimeout: 15 * 1000, // Timeout for action operations in milliseconds (15 sec)
-		trace: 'retain-on-first-failure',
+		trace: 'retain-on-failure',
 		baseURL: isProd ? 'https://leandropata.pt' : 'http://localhost:4321',
 		headless: isProd ? true : !!process.env.CI,
 		...(isProd && !process.env.CI

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -51,7 +51,7 @@ const isCurrentPage = (href: string) => {
 
 	return (
 		pathname === href ||
-		(href !== '/' && href !== `/${locale}` && pathname.startsWith(href))
+		(href !== '/' && href !== `/${locale}/` && pathname.startsWith(href))
 	);
 };
 ---


### PR DESCRIPTION
# Fix Locale Path

## Summary

This PR fixes an issue in the `Nav` component, where the locale path comparison was incorrect, and updates the version of the portfolio to 1.1.2.

## Changes

- Fix the locale path comparison in the `isCurrentPage` function within the `Nav` component;
- Bump the package version from 1.1.1 to 1.1.2;