### PR TITLE
Improved page loading in testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "portfolio",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "portfolio",
-			"version": "1.1.4",
+			"version": "1.1.5",
 			"dependencies": {
 				"@astrojs/sitemap": "^3.3.0",
 				"@yeskunall/astro-umami": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "portfolio",
 	"type": "module",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,10 +19,6 @@ const {
 
 <meta charset='UTF-8' />
 <meta
-	http-equiv='x-dns-prefetch-control'
-	content='off'
-/>
-<meta
 	name='description'
 	property='og:description'
 	content={description}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,6 +19,10 @@ const {
 
 <meta charset='UTF-8' />
 <meta
+	http-equiv='x-dns-prefetch-control'
+	content='off'
+/>
+<meta
 	name='description'
 	property='og:description'
 	content={description}

--- a/test/E2ETesting/fixtures.ts
+++ b/test/E2ETesting/fixtures.ts
@@ -1,0 +1,16 @@
+import { test as base, type Route } from '@playwright/test';
+
+// Block all image requests from external domains
+export const test = base.extend({
+	page: async ({ page }, use) => {
+		const blockExternalImages = (route: Route) => {
+			if (route.request().resourceType() === 'image') return route.abort();
+			return route.continue();
+		};
+
+		await page.route(/^https?:\/\/(?!localhost)/, blockExternalImages);
+		await use(page);
+	},
+});
+
+export { expect } from '@playwright/test';

--- a/test/E2ETesting/gallery.spec.ts
+++ b/test/E2ETesting/gallery.spec.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
-import { expect, test } from '@playwright/test';
 import getRoutes from '@/src/utils/getRoutes';
+import { expect, test } from '@/test/E2ETesting/fixtures';
 
 const routes = getRoutes(path.resolve('dist'));
 
@@ -8,7 +8,29 @@ test.describe('PhotoSwipe Gallery', () => {
 	for (const route of routes) {
 		test.describe(route, () => {
 			test.beforeEach(async ({ page }) => {
-				await page.route('**cdn.jsdelivr.net/**', (route) => route.abort());
+				// Continue all CDN requests
+				await page.route('https://cdn.jsdelivr.net/**', (route) =>
+					route.continue(),
+				);
+
+				/* page.on('console', (msg) => console.log('BROWSER: ', msg.text()));
+
+				await page.evaluate(() => {
+					window.addEventListener('load', () => console.log('LOAD FIRED'));
+				});
+
+				page.on('request', (req) => {
+					if (
+						!req.url().includes('localhost') &&
+						!req.url().includes('jsdelivr')
+					)
+						console.log('EXTERNAL REQUEST: ', req.resourceType(), req.url());
+				});
+
+				page.on('requestfailed', (req) =>
+					console.log('REQUEST FAILED: ', req.url(), req.failure()?.errorText),
+				); */
+
 				await page.goto(route, { waitUntil: 'load' });
 
 				if (route === '/')
@@ -33,7 +55,6 @@ test.describe('PhotoSwipe Gallery', () => {
 						failedRequests.push(`${response.url()} — ${response.status()}`);
 					}
 				});
-				await page.unroute('**cdn.jsdelivr.net/**');
 				await page.goto(route, { waitUntil: 'domcontentloaded' });
 
 				expect(failedRequests).toEqual([]);

--- a/test/E2ETesting/gallery.spec.ts
+++ b/test/E2ETesting/gallery.spec.ts
@@ -33,8 +33,7 @@ test.describe('PhotoSwipe Gallery', () => {
 					}
 				});
 
-				await page.goto(route);
-				await page.waitForLoadState('networkidle');
+				await page.goto(route, { waitUntil: 'domcontentloaded' });
 
 				expect(failedRequests).toEqual([]);
 			});

--- a/test/E2ETesting/gallery.spec.ts
+++ b/test/E2ETesting/gallery.spec.ts
@@ -8,6 +8,7 @@ test.describe('PhotoSwipe Gallery', () => {
 	for (const route of routes) {
 		test.describe(route, () => {
 			test.beforeEach(async ({ page }) => {
+				await page.route('**cdn.jsdelivr.net/**', (route) => route.abort());
 				await page.goto(route, { waitUntil: 'load' });
 
 				if (route === '/')
@@ -32,7 +33,7 @@ test.describe('PhotoSwipe Gallery', () => {
 						failedRequests.push(`${response.url()} — ${response.status()}`);
 					}
 				});
-
+				await page.unroute('**cdn.jsdelivr.net/**');
 				await page.goto(route, { waitUntil: 'domcontentloaded' });
 
 				expect(failedRequests).toEqual([]);

--- a/test/E2ETesting/gallery.spec.ts
+++ b/test/E2ETesting/gallery.spec.ts
@@ -9,9 +9,9 @@ test.describe('PhotoSwipe Gallery', () => {
 		test.describe(route, () => {
 			test.beforeEach(async ({ page }) => {
 				// Continue all CDN requests
-				await page.route('https://cdn.jsdelivr.net/**', (route) =>
+				/* await page.route('https://cdn.jsdelivr.net/**', (route) =>
 					route.continue(),
-				);
+				); */
 
 				/* page.on('console', (msg) => console.log('BROWSER: ', msg.text()));
 
@@ -45,6 +45,11 @@ test.describe('PhotoSwipe Gallery', () => {
 
 			test('Gallery images load correctly', async ({ page }) => {
 				const failedRequests: string[] = [];
+
+				// Continue all CDN requests
+				await page.route('https://cdn.jsdelivr.net/**', (route) =>
+					route.continue(),
+				);
 
 				page.on('response', (response) => {
 					if (
@@ -80,6 +85,11 @@ test.describe('PhotoSwipe Gallery', () => {
 			});
 
 			test('Lightbox navigates to next image', async ({ page, isMobile }) => {
+				// Continue all CDN requests
+				await page.route('https://cdn.jsdelivr.net/**', (route) =>
+					route.continue(),
+				);
+
 				await page.locator('#project-gallery a').first().click();
 				await expect(page.locator('.pswp')).toBeVisible();
 

--- a/test/E2ETesting/imageLoading.spec.ts
+++ b/test/E2ETesting/imageLoading.spec.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
-import { expect, test } from '@playwright/test';
 import getRoutes from '@/src/utils/getRoutes';
+import { expect, test } from '@/test/E2ETesting/fixtures';
 
 const routes = getRoutes(path.resolve('dist'));
 
@@ -8,6 +8,11 @@ test.describe('CDN links load correctly', () => {
 	for (const route of routes) {
 		test(`CDN links in ${route}`, async ({ page }) => {
 			const failedRequests: string[] = [];
+
+			// Continue all CDN requests
+			await page.route('https://cdn.jsdelivr.net/**', (route) =>
+				route.continue(),
+			);
 
 			// Intercept all network requests before navigating
 			page.on('response', (response) => {

--- a/test/E2ETesting/imageLoading.spec.ts
+++ b/test/E2ETesting/imageLoading.spec.ts
@@ -20,9 +20,7 @@ test.describe('CDN links load correctly', () => {
 				}
 			});
 
-			await page.goto(route);
-			// Wait for network to be idle so all images have had a chance to load
-			await page.waitForLoadState('networkidle');
+			await page.goto(route, { waitUntil: 'domcontentloaded' });
 
 			expect(failedRequests).toEqual([]);
 		});

--- a/test/E2ETesting/imageLoading.spec.ts
+++ b/test/E2ETesting/imageLoading.spec.ts
@@ -6,7 +6,7 @@ const routes = getRoutes(path.resolve('dist'));
 
 test.describe('CDN links load correctly', () => {
 	for (const route of routes) {
-		test(`CDN links in ${route}`, async ({ page }) => {
+		test(`CDN links in: ${route}`, async ({ page }) => {
 			const failedRequests: string[] = [];
 
 			// Continue all CDN requests

--- a/test/E2ETesting/languageSelect.spec.ts
+++ b/test/E2ETesting/languageSelect.spec.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
-import { expect, test } from '@playwright/test';
 import { languages } from '@/src/i18n/ui';
 import getRoutes from '@/src/utils/getRoutes';
+import { expect, test } from '@/test/E2ETesting/fixtures';
 
 const routes = getRoutes(path.resolve('dist'));
 

--- a/test/E2ETesting/languageSelect.spec.ts
+++ b/test/E2ETesting/languageSelect.spec.ts
@@ -25,7 +25,7 @@ test.describe('Language selection works correctly', () => {
 				test(`Language selector navigates to '${locale}' at ${route}`, async ({
 					page,
 				}) => {
-					await page.goto(`${route}`);
+					await page.goto(`${route}`, { waitUntil: 'domcontentloaded' });
 
 					await page.waitForSelector('#menu-toggle', {
 						state: 'attached',

--- a/test/E2ETesting/languageSelect.spec.ts
+++ b/test/E2ETesting/languageSelect.spec.ts
@@ -22,7 +22,7 @@ test.describe('Language selection works correctly', () => {
 					continue;
 				}
 
-				test(`Language selector navigates to '${locale}' at ${route}`, async ({
+				test(`Language selector navigates to '${locale}' at '${route}'`, async ({
 					page,
 				}) => {
 					await page.goto(`${route}`, { waitUntil: 'domcontentloaded' });

--- a/test/E2ETesting/nav.spec.ts
+++ b/test/E2ETesting/nav.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
 import { languages } from '@/src/i18n/ui';
+import { expect, test } from '@/test/E2ETesting/fixtures';
 
 test.describe('Navbar navigation', () => {
 	for (const locale in languages) {

--- a/test/E2ETesting/nav.spec.ts
+++ b/test/E2ETesting/nav.spec.ts
@@ -6,7 +6,7 @@ test.describe('Navbar navigation', () => {
 		test(`Load all pages in navbar for the ${locale} locale`, async ({
 			page,
 		}) => {
-			await page.goto(`/${locale}/`);
+			await page.goto(`/${locale}/`, { waitUntil: 'domcontentloaded' });
 
 			await page.waitForSelector('#menu-toggle', {
 				state: 'attached',

--- a/test/E2ETesting/nav.spec.ts
+++ b/test/E2ETesting/nav.spec.ts
@@ -3,9 +3,7 @@ import { expect, test } from '@/test/E2ETesting/fixtures';
 
 test.describe('Navbar navigation', () => {
 	for (const locale in languages) {
-		test(`Load all pages in navbar for the ${locale} locale`, async ({
-			page,
-		}) => {
+		test(`Load all pages in navbar for locale: ${locale}`, async ({ page }) => {
 			await page.goto(`/${locale}/`, { waitUntil: 'domcontentloaded' });
 
 			await page.waitForSelector('#menu-toggle', {

--- a/test/E2ETesting/pageLoading.spec.ts
+++ b/test/E2ETesting/pageLoading.spec.ts
@@ -6,7 +6,7 @@ const routes = getRoutes(path.resolve('dist'));
 
 test.describe('All pages exist and load correctly', () => {
 	for (const route of routes) {
-		test(`Loads ${route}`, async ({ page }) => {
+		test(`Loads '${route}'`, async ({ page }) => {
 			await page.goto(route, { waitUntil: 'domcontentloaded' });
 
 			if (route === '/') await expect(page).toHaveURL('/en/');

--- a/test/E2ETesting/pageLoading.spec.ts
+++ b/test/E2ETesting/pageLoading.spec.ts
@@ -7,7 +7,7 @@ const routes = getRoutes(path.resolve('dist'));
 test.describe('All pages exist and load correctly', () => {
 	for (const route of routes) {
 		test(`Loads ${route}`, async ({ page }) => {
-			await page.goto(route);
+			await page.goto(route, { waitUntil: 'domcontentloaded' });
 
 			if (route === '/') await expect(page).toHaveURL('/en/');
 			else await expect(page).toHaveURL(route);

--- a/test/E2ETesting/pageLoading.spec.ts
+++ b/test/E2ETesting/pageLoading.spec.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
-import { expect, test } from '@playwright/test';
 import getRoutes from '@/src/utils/getRoutes';
+import { expect, test } from '@/test/E2ETesting/fixtures';
 
 const routes = getRoutes(path.resolve('dist'));
 

--- a/test/E2ETesting/themeToggle.spec.ts
+++ b/test/E2ETesting/themeToggle.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 test('Theme toggle switches between light and dark mode', async ({ page }) => {
-	await page.goto('/');
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
 
 	await page.waitForSelector('#menu-toggle', {
 		state: 'attached',

--- a/test/E2ETesting/themeToggle.spec.ts
+++ b/test/E2ETesting/themeToggle.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@/test/E2ETesting/fixtures';
 
 test('Theme toggle switches between light and dark mode', async ({ page }) => {
 	await page.goto('/', { waitUntil: 'domcontentloaded' });

--- a/test/E2ETesting/umami.spec.ts
+++ b/test/E2ETesting/umami.spec.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
-import { expect, test } from '@playwright/test';
 import getRoutes from '@/src/utils/getRoutes';
+import { expect, test } from '@/test/E2ETesting/fixtures';
 
 const routes = getRoutes(path.resolve('dist'));
 
@@ -19,7 +19,6 @@ test('Umami script is present and reachable', async ({ page }) => {
 test.describe(`Umami events are reachable`, () => {
 	for (const route of routes) {
 		test(`Events in ${route}`, async ({ page }) => {
-			await page.route('**cdn.jsdelivr.net/**', (route) => route.abort());
 			await page.goto(route, { waitUntil: 'load' });
 
 			if (route === '/') await page.waitForURL((url) => url.pathname !== route);

--- a/test/E2ETesting/umami.spec.ts
+++ b/test/E2ETesting/umami.spec.ts
@@ -5,7 +5,7 @@ import getRoutes from '@/src/utils/getRoutes';
 const routes = getRoutes(path.resolve('dist'));
 
 test('Umami script is present and reachable', async ({ page }) => {
-	await page.goto('/');
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
 
 	const umamiScript = await page.locator('script[src*="umami"]').first();
 	const scriptSrc = await umamiScript.getAttribute('src');
@@ -19,7 +19,7 @@ test('Umami script is present and reachable', async ({ page }) => {
 test.describe(`Umami events are reachable`, () => {
 	for (const route of routes) {
 		test(`Events in ${route}`, async ({ page }) => {
-			await page.goto(route);
+			await page.goto(route, { waitUntil: 'load' });
 
 			if (route === '/') await page.waitForURL((url) => url.pathname !== route);
 

--- a/test/E2ETesting/umami.spec.ts
+++ b/test/E2ETesting/umami.spec.ts
@@ -19,6 +19,7 @@ test('Umami script is present and reachable', async ({ page }) => {
 test.describe(`Umami events are reachable`, () => {
 	for (const route of routes) {
 		test(`Events in ${route}`, async ({ page }) => {
+			await page.route('**cdn.jsdelivr.net/**', (route) => route.abort());
 			await page.goto(route, { waitUntil: 'load' });
 
 			if (route === '/') await page.waitForURL((url) => url.pathname !== route);

--- a/test/E2ETesting/umami.spec.ts
+++ b/test/E2ETesting/umami.spec.ts
@@ -18,7 +18,7 @@ test('Umami script is present and reachable', async ({ page }) => {
 
 test.describe(`Umami events are reachable`, () => {
 	for (const route of routes) {
-		test(`Events in ${route}`, async ({ page }) => {
+		test(`Events in: ${route}`, async ({ page }) => {
 			await page.goto(route, { waitUntil: 'load' });
 
 			if (route === '/') await page.waitForURL((url) => url.pathname !== route);


### PR DESCRIPTION
# Improved page loading in testing

## Summary

Updated the test suite to use `domcontentloaded` instead of `networkidle`, when applicable, for better control over when tests execute. This ensures that tests run when the DOM is fully loaded, improving reliability and performance. Also added test fixtures to avoid tests being network dependent whenever possible.

## Changes

- Updated wait strategy in multiple tests:
  - In `test/E2ETesting/gallery.spec.ts`, updated the `page.goto` call to use `{ waitUntil: 'domcontentloaded' }`;
  - In `test/E2ETesting/imageLoading.spec.ts`, updated the `page.goto` call to use `{ waitUntil: 'domcontentloaded' }`;
  - In `test/E2ETesting/languageSelect.spec.ts`, updated the `page.goto` call to use `{ waitUntil: 'domcontentloaded' }`;
  - In `test/E2ETesting/nav.spec.ts`, updated the `page.goto` call to use `{ waitUntil: 'domcontentloaded' }`;
  - In `test/E2ETesting/pageLoading.spec.ts`, updated the `page.goto` call to use `{ waitUntil: 'domcontentloaded' }`;
  - In `test/E2ETesting/themeToggle.spec.ts`, updated the `page.goto` call to use `{ waitUntil: 'domcontentloaded' }`;
  - In `test/E2ETesting/umami.spec.ts`, updated the `page.goto` calls to use `{ waitUntil: 'load' }`;

- Added a new fixture file (`test/E2ETesting/fixtures.ts`) to block all image requests from external domains;
- Updated various test files to use this new fixture, ensuring that network requests are controlled during tests;

## Notes

The new fixture provides better isolation for tests, reducing flakiness due to external CDN requests.
The `Lightbox navigates to next image` test in `gallery.spec.ts` still is still CDN dependent, because the test compares the current image to the next image to check if it actually navigated to the next image. Without it actually loading the images, it would be comparing null to null, so, until I can mock this, it will stay network dependent.