### PR TITLE
Add Accessibility and SEO Meta Tags Tests

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,4 @@
 // @ts-check
-
 import sitemap from '@astrojs/sitemap';
 import yeskunallumami from '@yeskunall/astro-umami';
 import { defineConfig } from 'astro/config';
@@ -36,6 +35,16 @@ export default defineConfig({
 		defaultLocale: 'en',
 		routing: {
 			prefixDefaultLocale: true,
+		},
+	},
+	markdown: {
+		shikiConfig: {
+			themes: {
+				light: 'light-plus',
+				dark: 'dark-plus',
+			},
+			defaultColor: false,
+			wrap: true,
 		},
 	},
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.3.3",
 			"dependencies": {
 				"@astrojs/sitemap": "^3.7.2",
+				"@axe-core/playwright": "^4.11.3",
 				"@yeskunall/astro-umami": "^0.0.8",
 				"astro": "^6.1.7",
 				"photoswipe": "^5.4.4"
@@ -103,6 +104,18 @@
 			},
 			"engines": {
 				"node": "18.20.8 || ^20.3.0 || >=22.0.0"
+			}
+		},
+		"node_modules/@axe-core/playwright": {
+			"version": "4.11.3",
+			"resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+			"integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+			"license": "MPL-2.0",
+			"dependencies": {
+				"axe-core": "~4.11.4"
+			},
+			"peerDependencies": {
+				"playwright-core": ">= 1.0.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
@@ -2028,6 +2041,15 @@
 			},
 			"optionalDependencies": {
 				"sharp": "^0.34.0"
+			}
+		},
+		"node_modules/axe-core": {
+			"version": "4.11.4",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+			"integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+			"license": "MPL-2.0",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/axobject-query": {
@@ -4109,7 +4131,6 @@
 			"version": "1.59.1",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
 			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	},
 	"dependencies": {
 		"@astrojs/sitemap": "^3.7.2",
+		"@axe-core/playwright": "^4.11.3",
 		"@yeskunall/astro-umami": "^0.0.8",
 		"astro": "^6.1.7",
 		"photoswipe": "^5.4.4"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,10 +1,24 @@
 ---
 import '@/src/styles/global.css';
 import { ClientRouter } from 'astro:transitions';
-import { useTranslations } from '@/src/i18n/utils';
+import { defaultLang } from '@/src/i18n/ui';
+import { getAllLocales, useTranslations } from '@/src/i18n/utils';
+import { CDN } from '@/src/utils/constants';
 
 const locale = Astro.currentLocale;
 const t = useTranslations(locale);
+
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+
+const LOCALES = getAllLocales();
+const alternates = LOCALES.map(loc => ({
+	hreflang: loc, 
+	url: new URL(Astro.url.pathname.replace(new RegExp(`^/${locale}`), `/${loc}`), 
+	Astro.site,
+	)
+}));
+
+const defaultURL = alternates.find(a => a.hreflang === defaultLang)?.url;
 
 interface Props {
 	title?: string | undefined;
@@ -19,11 +33,6 @@ const {
 
 <meta charset='UTF-8' />
 <meta
-	name='description'
-	property='og:description'
-	content={description}
-/>
-<meta
 	name='viewport'
 	content='width=device-width'
 />
@@ -32,6 +41,7 @@ const {
 	content={Astro.generator}
 />
 <title>{title}</title>
+<meta name="description" content={description}>
 
 <link
 	rel='icon'
@@ -58,6 +68,45 @@ const {
 <link
 	rel='sitemap'
 	href='/sitemap-index.xml'
+/>
+
+<link
+	rel='canonical'
+	href={canonicalURL}
+/>
+
+{alternates.map(({ hreflang, url }) => (
+	<link rel="alternate" hreflang={hreflang} href={url} />
+))}
+
+{defaultURL && (
+	<link rel="alternate" hreflang="x-default" href={defaultURL} />
+)}
+
+<!-- Open Graph tags -->
+<meta 
+	property="og:title" 
+	content={title} 
+/>
+<meta 
+	property="og:type" 
+	content="Portfolio"
+/>
+<meta 
+	property="og:url" 
+	content={canonicalURL}
+/>
+<meta 
+	property="og:description" 
+	content={description}
+/>
+<meta 
+	property="og:image" 
+	content={CDN+'/assets/projects/portfolio/cover.jpg'}
+/>
+<meta 
+	property="og:image:alt" 
+	content="Portfolio Cover"
 />
 
 <ClientRouter />

--- a/src/components/LanguageSelect.astro
+++ b/src/components/LanguageSelect.astro
@@ -7,6 +7,7 @@ import getFlagEmoji from '@/src/utils/getLanguageFlag';
 	<select
 		name='language-select'
 		id='language-select'
+		aria-label='Select language'
 	>
 		{
 			Object.entries(languages).map(([lang, label]) => (

--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -6,7 +6,7 @@ const locale = Astro.currentLocale;
 const t = useTranslations(locale);
 ---
 
-<section class='box skills'>
+<section class='box skills' aria-label='Core Skills'>
 	<div
 		class='stack gap-2 lg:gap-4'
 		style='align-items: center'

--- a/src/content/projects/en/portfolio.md
+++ b/src/content/projects/en/portfolio.md
@@ -44,9 +44,9 @@ tags:
 <h1 style='text-align: center;'>Portfolio</h1>
 
 <p align="center">
-<img src="https://img.shields.io/github/package-json/v/LeandroPata/Portfolio">
-<a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
-<a href="https://github.com/LeandroPata/Portfolio/actions/workflows/deploy.yml"><img src="https://github.com/LeandroPata/Portfolio/actions/workflows/deploy.yml/badge.svg?event=push"></a>
+<img src="https://img.shields.io/github/package-json/v/LeandroPata/Portfolio" alt="Current Version">
+<a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+<a href="https://github.com/LeandroPata/Portfolio/actions/workflows/deploy.yml"><img src="https://github.com/LeandroPata/Portfolio/actions/workflows/deploy.yml/badge.svg?event=push" alt="Workflow Badge"></a>
 </p>
 
 Personal portfolio project.

--- a/src/content/projects/en/wallTheme.md
+++ b/src/content/projects/en/wallTheme.md
@@ -17,9 +17,9 @@ tags:
 <h1 style='text-align: center;'>WallTheme</h1>
 
 <p align="center">
-<a href="https://pypi.python.org/pypi/walltheme/"><img src="https://img.shields.io/pypi/v/walltheme.svg"></a>
-<a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
-<a href="https://github.com/LeandroPata/WallTheme/actions/workflows/release.yml"><img src="https://github.com/LeandroPata/WallTheme/actions/workflows/release.yml/badge.svg"></a>
+<a href="https://pypi.python.org/pypi/walltheme/"><img src="https://img.shields.io/pypi/v/walltheme.svg" alt="Current Version"></a>
+<a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+<a href="https://github.com/LeandroPata/WallTheme/actions/workflows/release.yml"><img src="https://github.com/LeandroPata/WallTheme/actions/workflows/release.yml/badge.svg" alt="Workflow Badge"></a>
 </p>
 
 ## A color-scheme generation tool

--- a/src/content/projects/pt/portfolio.md
+++ b/src/content/projects/pt/portfolio.md
@@ -44,9 +44,9 @@ tags:
 <h1 style='text-align: center;'>Portfolio</h1>
 
 <p align="center">
-<img src="https://img.shields.io/github/package-json/v/LeandroPata/Portfolio">
-<a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
-<a href="https://github.com/LeandroPata/Portfolio/actions/workflows/deploy.yml"><img src="https://github.com/LeandroPata/Portfolio/actions/workflows/deploy.yml/badge.svg?event=push"></a>
+<img src="https://img.shields.io/github/package-json/v/LeandroPata/Portfolio" alt="Current Version">
+<a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+<a href="https://github.com/LeandroPata/Portfolio/actions/workflows/deploy.yml"><img src="https://github.com/LeandroPata/Portfolio/actions/workflows/deploy.yml/badge.svg?event=push" alt="Workflow Badge"></a>
 </p>
 
 Projeto de portfolio pessoal.

--- a/src/content/projects/pt/wallTheme.md
+++ b/src/content/projects/pt/wallTheme.md
@@ -17,9 +17,9 @@ tags:
 <h1 style='text-align: center;'>WallTheme</h1>
 
 <p align="center">
-<a href="https://pypi.python.org/pypi/walltheme/"><img src="https://img.shields.io/pypi/v/walltheme.svg"></a>
-<a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
-<a href="https://github.com/LeandroPata/WallTheme/actions/workflows/release.yml"><img src="https://github.com/LeandroPata/WallTheme/actions/workflows/release.yml/badge.svg"></a>
+<a href="https://pypi.python.org/pypi/walltheme/"><img src="https://img.shields.io/pypi/v/walltheme.svg" alt="Current Version"></a>
+<a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+<a href="https://github.com/LeandroPata/WallTheme/actions/workflows/release.yml"><img src="https://github.com/LeandroPata/WallTheme/actions/workflows/release.yml/badge.svg" alt="Workflow Badge"></a>
 </p>
 
 ## Uma ferramenta para gerar palettes de cores

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,5 +1,9 @@
 import { defaultLang, languages, ui } from '@/src/i18n/ui';
 
+export function getAllLocales(): (keyof typeof languages)[] {
+	return Object.keys(languages) as (keyof typeof languages)[];
+}
+
 export function getLangFromUrl(path: string): keyof typeof languages {
 	// Default to DefaultLang for the root path or invalid paths
 	const parts = path.split('/');

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -44,8 +44,8 @@ const t = useTranslations(locale);
 					{
 						t('about.educationContent').map((education) => (
 							<div class='education'>
-								<h3 class='content-title'>{education[0]}</h5>
-								<h3 class='content-date'>{education[1]}</h5>
+								<h3 class='content-title'>{education[0]}</h3>
+								<h3 class='content-date'>{education[1]}</h3>
 								<p>{education[2]}</p>
 							</div>
 						))
@@ -61,8 +61,8 @@ const t = useTranslations(locale);
 					{
 						t('about.workContent').map((work) => (
 							<div class='work'>
-								<h3 class='content-title'>{work[0]}</h5>
-								<h3 class='content-date'>{work[1]}</h5>
+								<h3 class='content-title'>{work[0]}</h3>
+								<h3 class='content-date'>{work[1]}</h3>
 								<p>{work[2]}</p>
 							</div>
 						))
@@ -87,7 +87,7 @@ const t = useTranslations(locale);
 					{
 						t('about.certificateContent').map((certificate) => (
 							<div class='certificate'>
-								<h3>{certificate}</h5>
+								<h3>{certificate}</h3>
 							</div>
 						))
 					}

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -44,8 +44,8 @@ const t = useTranslations(locale);
 					{
 						t('about.educationContent').map((education) => (
 							<div class='education'>
-								<h5 class='content-title'>{education[0]}</h5>
-								<h5 class='content-date'>{education[1]}</h5>
+								<h3 class='content-title'>{education[0]}</h5>
+								<h3 class='content-date'>{education[1]}</h5>
 								<p>{education[2]}</p>
 							</div>
 						))
@@ -61,8 +61,8 @@ const t = useTranslations(locale);
 					{
 						t('about.workContent').map((work) => (
 							<div class='work'>
-								<h5 class='content-title'>{work[0]}</h5>
-								<h5 class='content-date'>{work[1]}</h5>
+								<h3 class='content-title'>{work[0]}</h5>
+								<h3 class='content-date'>{work[1]}</h5>
 								<p>{work[2]}</p>
 							</div>
 						))
@@ -87,7 +87,7 @@ const t = useTranslations(locale);
 					{
 						t('about.certificateContent').map((certificate) => (
 							<div class='certificate'>
-								<h5>{certificate}</h5>
+								<h3>{certificate}</h5>
 							</div>
 						))
 					}
@@ -95,14 +95,14 @@ const t = useTranslations(locale);
 			</section>
 		</main>
 
-		<div class='cv-download'>
+		<aside class='cv-download' aria-label='CV Download'>
 			<a 
 				href={`${CDN}/assets/cv/CV_LeandroPata_EN.pdf`} 
 				target='_blank' 
 				data-umami-event='CV Click'>
 				{t('about.cv')}
 			</a>
-		</div>
+		</aside>
 		<ContactCTA />
 	</div>
 </MainLayout>

--- a/src/pages/[lang]/projects/[...slug].astro
+++ b/src/pages/[lang]/projects/[...slug].astro
@@ -5,7 +5,7 @@ import Hero from '@/src/components/Hero.astro';
 import PhotoswipeGallery from '@/src/components/PhotoswipeGallery.astro';
 import Pill from '@/src/components/Pill.astro';
 import { defaultLang, languages } from '@/src/i18n/ui';
-import { useTranslations } from '@/src/i18n/utils';
+import { getAllLocales, useTranslations } from '@/src/i18n/utils';
 import MainLayout from '@/src/layouts/MainLayout.astro';
 import { CDN } from '@/src/utils/constants';
 import { loadCollection } from '@/src/utils/loadData';
@@ -15,7 +15,7 @@ const t = useTranslations(locale);
 
 // This is a dynamic route that generates a page for every Markdown file in src/content/
 export async function getStaticPaths() {
-	const langs = Object.keys(languages) as (keyof typeof languages)[];
+	const langs = getAllLocales();
 
 	const paths = await Promise.all(
 		langs.map(async (lang) => {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -208,10 +208,7 @@ pre {
 }
 
 pre code {
-	background-color: transparent;
 	padding: 0;
-	font-size: var(--text-md);
-	line-height: 1.45;
 }
 
 /* Utilities */
@@ -263,6 +260,18 @@ pre code {
 }
 .gap-48 {
 	gap: 12rem;
+}
+
+.astro-code,
+.astro-code span {
+		color: var(--shiki-light);
+		background-color: var(--shiki-light-bg);
+}
+
+:root.dark .astro-code,
+:root.dark .astro-code span {
+		color: var(--shiki-dark);
+		background-color: var(--shiki-dark-bg);
 }
 
 @media (min-width: 50em) {

--- a/test/E2ETesting/a11y.spec.ts
+++ b/test/E2ETesting/a11y.spec.ts
@@ -1,0 +1,68 @@
+import path from 'node:path';
+import AxeBuilder from '@axe-core/playwright';
+import getRoutes from '@/src/utils/getRoutes';
+import { expect, test } from '@/test/E2ETesting/fixtures';
+
+const routes = getRoutes(path.resolve('dist'));
+
+test.describe('Accessibility Testing', () => {
+	for (const route of routes) {
+		test(`Accessibility in: ${route} with Light Theme`, async ({ page }) => {
+			await page.goto(route, { waitUntil: 'load' });
+			if (route === '/') await page.waitForURL((url) => url.pathname !== route);
+
+			await page.waitForSelector('#menu-toggle', {
+				state: 'attached',
+			});
+
+			if (await page.locator('#menu-toggle').isVisible())
+				await page.locator('#menu-toggle').click();
+
+			const html = page.locator('html');
+			const button = page.locator('theme-toggle button');
+
+			const hasDark = await html.evaluate((el) =>
+				el.classList.contains('dark'),
+			);
+			if (hasDark) await button.click();
+
+			const confirmDark = await html.evaluate((el) =>
+				el.classList.contains('dark'),
+			);
+
+			expect(confirmDark).toBeFalsy();
+
+			const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+			expect(accessibilityScanResults.violations).toEqual([]);
+		});
+
+		test(`Accessibility in: ${route} with Dark Theme`, async ({ page }) => {
+			await page.goto(route, { waitUntil: 'load' });
+			if (route === '/') await page.waitForURL((url) => url.pathname !== route);
+
+			await page.waitForSelector('#menu-toggle', {
+				state: 'attached',
+			});
+
+			if (await page.locator('#menu-toggle').isVisible())
+				await page.locator('#menu-toggle').click();
+
+			const html = page.locator('html');
+			const button = page.locator('theme-toggle button');
+
+			const hasDark = await html.evaluate((el) =>
+				el.classList.contains('dark'),
+			);
+			if (!hasDark) await button.click();
+
+			const confirmDark = await html.evaluate((el) =>
+				el.classList.contains('dark'),
+			);
+
+			expect(confirmDark).toBeTruthy();
+
+			const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+			expect(accessibilityScanResults.violations).toEqual([]);
+		});
+	}
+});

--- a/test/E2ETesting/meta.spec.ts
+++ b/test/E2ETesting/meta.spec.ts
@@ -1,0 +1,87 @@
+import path from 'node:path';
+import { getAllLocales, getLangFromUrl } from '@/src/i18n/utils';
+import getRoutes from '@/src/utils/getRoutes';
+import { expect, test } from '@/test/E2ETesting/fixtures';
+
+const routes = getRoutes(path.resolve('dist'));
+const locales = getAllLocales();
+
+test.describe('SEO meta tags', () => {
+	for (const route of routes) {
+		test(`Meta Tags in: ${route}`, async ({ page }) => {
+			await page.goto(route, { waitUntil: 'domcontentloaded' });
+			if (route === '/') await page.waitForURL((url) => url.pathname !== route);
+
+			// Title
+			const title = await page.title();
+			expect(title, '<title> must not be empty').toBeTruthy();
+			expect(title, '<title> must not be the Astro default').not.toBe('Astro');
+
+			// Description
+			const description = await page
+				.locator('meta[name="description"]')
+				.getAttribute('content');
+			expect(
+				description,
+				'meta description must be present and non-empty',
+			).toBeTruthy();
+
+			// Open Graph
+			const ogTitle = await page
+				.locator('meta[property="og:title"]')
+				.getAttribute('content');
+			expect(ogTitle, 'og:title must be present').toBeTruthy();
+
+			const ogType = await page
+				.locator('meta[property="og:type"]')
+				.getAttribute('content');
+			expect(ogType, 'og:type must be present').toBeTruthy();
+
+			const ogURL = await page
+				.locator('meta[property="og:url"]')
+				.getAttribute('content');
+			expect(ogURL, 'og:url must be present').toBeTruthy();
+
+			const ogDescription = await page
+				.locator('meta[property="og:description"]')
+				.getAttribute('content');
+			expect(ogDescription, 'og:description must be present').toBeTruthy();
+
+			const ogImage = await page
+				.locator('meta[property="og:image"]')
+				.getAttribute('content');
+			expect(ogImage, 'og:image must be present').toBeTruthy();
+
+			const ogImageAlt = await page
+				.locator('meta[property="og:image:alt"]')
+				.getAttribute('content');
+			expect(ogImageAlt, 'og:image:alt must be present').toBeTruthy();
+
+			// Canonical
+			const canonical = await page
+				.locator('link[rel="canonical"]')
+				.getAttribute('href');
+			expect(canonical, 'canonical link must be present').toBeTruthy();
+
+			expect(ogURL, 'og:url must match canonical link').toBe(canonical);
+
+			// Locale Specific
+			const locale = getLangFromUrl(route);
+			if (locale) {
+				const lang = await page.locator('html').getAttribute('lang');
+				expect(lang, 'html[lang] must match route locale');
+
+				for (const loc of locales) {
+					const hrefLang = await page
+						.locator(`link[rel="alternate"][hreflang="${loc}"]`)
+						.getAttribute('href');
+
+					expect(
+						hrefLang,
+						`hrefLang="${loc}" alternate must be present`,
+					).toBeTruthy();
+				}
+			}
+		});
+	}
+});


### PR DESCRIPTION
# Add Accessibility and SEO Meta Tags Tests

## Summary

This PR adds E2E tests for accessibility and SEO meta tags. Additionally, it updates the `astro.config.mjs` file to include Shiki syntax highlighting configuration.

## Changes

- Updated `astro.config.mjs`:
   - Added Shiki syntax highlighting configuration under the `markdown` section;
   
- Updated `global.css`:
   - Added `astro-code` styles for both light and dark themes;

- Created new E2E test files:
   - `test/E2ETesting/a11y.spec.ts`: Tests for accessibility using `@axe-core/playwright`;
   - `test/E2ETesting/meta.spec.ts`: Tests for SEO meta tags;

- Added additional meta tags in `Header.astro`:
   - Added `Open Graph` tags;
   - Added alternate `href` for all available locales;
   - Added `canonical` tag and ensured that the `<link rel="canonical">` tag dynamically updates based on the current page URL;
   
- Fixed accessibility problems:
   - Added missing `alt` attributes in: 
     - `projects/en/wallTheme.md`;
     - `projects/pt/wallTheme.md`;
     - `projects/en/portfolio.md`;
     - `projects/pt/portfolio.md`;
   - Added missing `aria-label` attributes in:
     - `Skills.astro`;
     - `LanguageSelect.astro`;
     - `[lang]/about.astro`;
   - Changed misaligned `h5` content to `h3` in `[lang]/about.astro`;

- Updated `i18n/utils.ts` to include a function for getting all locales:
   - Added a function `getAllLocales` to return an array of all locale keys;

- Updated dynamic routes in `[lang]/projects/[...slug].astro`:
   - Used the `getAllLocales` function to return an array of all locale keys;

## Notes

The PR includes updates to the project's accessibility testing by leveraging `@axe-core/playwright`. This will help in identifying any potential issues related to web accessibility. Additionally, the tests ensure that all pages have the correct `<meta>` tags for SEO, including title, description, Open Graph tags, and canonical links.